### PR TITLE
[Finished] Fix transforming body to string issue

### DIFF
--- a/lib/rack/idempotency/response.rb
+++ b/lib/rack/idempotency/response.rb
@@ -16,7 +16,7 @@ module Rack
       end
 
       def to_a
-        [status, headers.to_hash, body.each(&:to_s)]
+        [status, headers.to_hash, body.each { |b| b.to_s }]
       end
 
       def to_json


### PR DESCRIPTION
There was an error which breaks some styles in Rails Server logs from this gem:
```ERROR NoMethodError: undefined method `each' for #<String:0x000055d484719568>
	./.rvm/gems/ruby-2.4.5/gems/rack-1.6.12/lib/rack/body_proxy.rb:31:in `each'
	./.rvm/gems/ruby-2.4.5/gems/rack-1.6.12/lib/rack/body_proxy.rb:31:in `each'```
This PR solves the issue.